### PR TITLE
Docs via github pages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/rust-docs.yml
+++ b/.github/workflows/rust-docs.yml
@@ -1,0 +1,45 @@
+name: Rust Docs Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - develop
+      - docs-online
+  workflow_dispatch:
+
+# Set permissions for GITHUB_TOKEN to allow GitHub Pages deployments
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Run Rust Doc
+        run: cargo doc --no-deps --workspace
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './target/thumbv8*/doc/' # Folder containing the files to host
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/rust-docs.yml
+++ b/.github/workflows/rust-docs.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './target/thumbv8*/doc/' # Folder containing the files to host
+          path: './target/thumbv8m.main-none-eabihf/doc/' # Folder containing the files to host
 
   deploy:
     environment:

--- a/utilities/cangen/cangen-macro/src/lib.rs
+++ b/utilities/cangen/cangen-macro/src/lib.rs
@@ -7,7 +7,7 @@ use syn::Ident;
 
 extern crate proc_macro;
 
-const CANGEN_SPEC_PATH: &str = "../Odyssey-Definitions/can-messages/";
+const CANGEN_SPEC_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/Odyssey-Definitions/can-messages/");
 
 #[proc_macro]
 pub fn generate_all_messages(_stream: TokenStream) -> TokenStream {


### PR DESCRIPTION
Ugly because cargo doc has no concept of an index page.

You must go to a specific page.
Such as adbms6830/all or cangen/all
https://northeastern-electric-racing.github.io/firmware-rs/cangen/all.html