### PR TITLE
cangen: Path Fix

### DIFF
--- a/utilities/cangen/cangen-macro/src/lib.rs
+++ b/utilities/cangen/cangen-macro/src/lib.rs
@@ -7,7 +7,7 @@ use syn::Ident;
 
 extern crate proc_macro;
 
-const CANGEN_SPEC_PATH: &str = "../Odyssey-Definitions/can-messages/";
+const CANGEN_SPEC_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/Odyssey-Definitions/can-messages/");
 
 #[proc_macro]
 pub fn generate_all_messages(_stream: TokenStream) -> TokenStream {


### PR DESCRIPTION
Uses `CARGO_MANIFEST_DIR` for `CANGEN_SPEC_PATH` instead of `../`.